### PR TITLE
Fix compilation on 32bit systems

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -7,5 +7,6 @@
             --x64 %{arch_sixtyfour} -o optint)))
 
 (library
+ (modules     optint)
  (name        optint)
  (public_name optint))

--- a/src/select/select.ml
+++ b/src/select/select.ml
@@ -29,7 +29,7 @@ let () =
     load_file (if is_x64 then "int_x64_backend.ml" else "int_x86_backend.ml")
   in
   let contents_mli =
-    load_file (if is_x64 then "int_x64_backend.mli" else "inx_x86_backend.mli")
+    load_file (if is_x64 then "int_x64_backend.mli" else "int_x86_backend.mli")
   in
   store_file (output ^ ".ml") contents_ml ;
   store_file (output ^ ".mli") contents_mli


### PR DESCRIPTION
Compiling optint on armv7 (32bit) gives following errors:

```
#=== ERROR while compiling optint.0.0.2 =======================================#
# context     2.0.1 | linux/arm32 | ocaml-variants.4.07.1+flambda | pinned(git+file:///home/user/optint#master#6add0afe)
# path        ~/.opam/4.07.1+flambda/.opam-switch/build/optint.0.0.2
# command     ~/.opam/4.07.1+flambda/bin/dune build -p optint -j 1
# exit-code   1
# env-file    ~/.opam/log/optint-6531-b76d46.env
# output-file ~/.opam/log/optint-6531-b76d46.out
### output ###
#        ocaml src/optint.{ml,mli} (exit 2)
# (cd _build/default/src && /home/user/.opam/4.07.1+flambda/bin/ocaml select/select.ml --x64 false -o optint)
# Exception: Sys_error "inx_x86_backend.mli: No such file or directory".
#     ocamlopt src/.optint.objs/optint__Int_x64_backend.{cmx,o} (exit 2)
# (cd _build/default && /home/user/.opam/4.07.1+flambda/bin/ocamlopt.opt -w -40 -g -I src/.optint.objs -I src/.optint.objs/.private -intf-suffix .ml -no-alias-deps -open Optint__ -o src/.optint.objs/optint__Int_x64_backend.cmx -c -impl src/int_x64_backend.ml)
# File "src/int_x64_backend.ml", line 20, characters 28-38:
# Error: Integer literal exceeds the range of representable integers of type int
#       ocamlc src/.optint.objs/optint__Int_x64_backend.{cmo,cmt} (exit 2)
# (cd _build/default && /home/user/.opam/4.07.1+flambda/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.optint.objs -I src/.optint.objs/.private -intf-suffix .ml -no-alias-deps -open Optint__ -o src/.optint.objs/optint__Int_x64_backend.cmo -c -impl src/int_x64_backend.ml)
# File "src/int_x64_backend.ml", line 20, characters 28-38:
# Error: Integer literal exceeds the range of representable integers of type int
```
This PR fixes one typo in select.ml and excludes arch-specific files from library.