### PR TITLE
fuzz_int63: source randomly-generated int32 types from AFL

### DIFF
--- a/fuzz/fuzz_int63.ml
+++ b/fuzz/fuzz_int63.ml
@@ -4,9 +4,8 @@ let int = le Int.max_int
 
 let int32 =
   let gen_random =
-    Random.self_init ();
     let open Int32 in
-    let bits () = of_int (Random.bits ()) in
+    let bits () = of_int (Gen.bits ()) in
     fun () -> logxor (bits ()) (shift_left (bits ()) 30)
   in
   let pos = easily_constructible gen_random PPrintOCaml.int32 in


### PR DESCRIPTION
Very minor fix, since this `int32` type is barely used, but easy to fix too.

CC @pascutto; thanks!