### PR TITLE
Add a mechanism for determining the implementation of `Int63.t`

### DIFF
--- a/fuzz/dune
+++ b/fuzz/dune
@@ -13,6 +13,12 @@
  (modules fuzz_int63)
  (libraries monolith optint))
 
+;; Ensure that [fuzz_int63] compiles in tests
+(alias
+ (name runtest)
+ (deps fuzz_int63.exe)
+ (action progn))
+
 (alias
  (name fuzz_int63)
  (action (run %{exe:fuzz_int63.exe})))

--- a/fuzz/fuzz_int63.ml
+++ b/fuzz/fuzz_int63.ml
@@ -15,7 +15,7 @@ let int32 =
 let float = deconstructible PPrintOCaml.float
 let string = deconstructible PPrint.string
 
-module type INTEGER = Optint.Private.S
+module type INTEGER = module type of Optint.Int63.Boxed
 
 module Fuzz_integer_equivalence (Reference : INTEGER) (Candidate : INTEGER) =
 struct
@@ -97,7 +97,7 @@ struct
 end
 
 module Reference = Optint.Int63
-module Candidate = Optint.Private.Int63_boxed
+module Candidate = Optint.Int63.Boxed
 module Int63_equiv = Fuzz_integer_equivalence (Reference) (Candidate)
 
 let () =

--- a/src/int63_native.mli
+++ b/src/int63_native.mli
@@ -1,3 +1,3 @@
-type t [@@immediate]
+type t = int [@@immediate]
 
 include Integer_interface.S with type t := t

--- a/src/optint.ml
+++ b/src/optint.ml
@@ -58,4 +58,15 @@ module Private = struct
   module type S = Integer_interface.S
 
   module Int63_boxed = Int63_emul
+
+  module Conditional = struct
+    type ('t, 'u, 'v) t =
+      | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
+      | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
+  end
+
+  let int63_is_immediate : (Int63.t, int, Int63_boxed.t) Conditional.t =
+    match Int63.repr with
+    | Immediate -> True
+    | Non_immediate -> False
 end

--- a/src/optint.ml
+++ b/src/optint.ml
@@ -39,6 +39,12 @@ module Optint = struct
   include (val impl : S)
 end
 
+module Conditional = struct
+  type ('t, 'u, 'v) t =
+    | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
+    | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
+end
+
 module Int63 = struct
   include Immediate64.Make (Int63_native) (Int63_emul)
 
@@ -50,23 +56,13 @@ module Int63 = struct
     | Non_immediate -> (module Int63_emul : S)
 
   include (val impl : S)
-end
 
-include Optint
+  module Boxed = Int63_emul
 
-module Private = struct
-  module type S = Integer_interface.S
-
-  module Int63_boxed = Int63_emul
-
-  module Conditional = struct
-    type ('t, 'u, 'v) t =
-      | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
-      | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
-  end
-
-  let int63_is_immediate : (Int63.t, int, Int63_boxed.t) Conditional.t =
-    match Int63.repr with
+  let is_immediate : (t, int, Boxed.t) Conditional.t =
+    match repr with
     | Immediate -> True
     | Non_immediate -> False
 end
+
+include Optint

--- a/src/optint.mli
+++ b/src/optint.mli
@@ -1,19 +1,19 @@
-module Optint : sig
-  type t [@@immediate64]
+type t [@@immediate64]
+(** The type of integers with {i at least} 32 bits.
+    For 63-bit integers, see {!Int63}. *)
 
-  include Integer_interface.S with type t := t
-  (** @inline *)
-end
+include Integer_interface.S with type t := t
+(** @inline *)
+
+(** {1 Other modules} *)
 
 module Int63 : sig
   type t [@@immediate64]
+  (** The type of integers with exactly 63-bits. *)
 
   include Integer_interface.S with type t := t
   (** @inline *)
 end
-
-include module type of Optint
-(** @inline *)
 
 (** Utilities with no stability guarantee, exposed for internal use. *)
 module Private : sig

--- a/src/optint.mli
+++ b/src/optint.mli
@@ -7,6 +7,7 @@ include Integer_interface.S with type t := t
 
 (** {1 Other modules} *)
 
+(** 63-bit integers. *)
 module Int63 : sig
   type t [@@immediate64]
   (** The type of integers with exactly 63-bits. *)
@@ -19,7 +20,20 @@ end
 module Private : sig
   module type S = Integer_interface.S
 
-  module Int63_boxed = Int63_emul
+  module Int63_boxed : S
   (** An implementation of 63-bit integers that always uses a boxed
       representation regardless of word size. *)
+
+  (** A conditional type equality, used for revealing that a type [t] has one of
+      two possible implementation types [u] and [v]. *)
+  module Conditional : sig
+    type ('t, 'u, 'v) t =
+      | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
+      | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
+  end
+
+  (** [int63_is_immediate] reveals the implementation of {!Int63.t} on the
+      current platform, and can be used to build [Int63] operations that behave
+      differently depending on the underlying representation, such as FFIs. *)
+  val int63_is_immediate : (Int63.t, int, Int63_boxed.t) Conditional.t
 end

--- a/src/optint.mli
+++ b/src/optint.mli
@@ -7,6 +7,14 @@ include Integer_interface.S with type t := t
 
 (** {1 Other modules} *)
 
+(** A conditional type equality, used for revealing that a type [t] has one of
+    two possible implementation types [u] and [v]. *)
+module Conditional : sig
+  type ('t, 'u, 'v) t =
+    | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
+    | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
+end
+
 (** 63-bit integers. *)
 module Int63 : sig
   type t [@@immediate64]
@@ -14,26 +22,13 @@ module Int63 : sig
 
   include Integer_interface.S with type t := t
   (** @inline *)
-end
 
-(** Utilities with no stability guarantee, exposed for internal use. *)
-module Private : sig
-  module type S = Integer_interface.S
-
-  module Int63_boxed : S
+  module Boxed : Integer_interface.S
   (** An implementation of 63-bit integers that always uses a boxed
       representation regardless of word size. *)
 
-  (** A conditional type equality, used for revealing that a type [t] has one of
-      two possible implementation types [u] and [v]. *)
-  module Conditional : sig
-    type ('t, 'u, 'v) t =
-      | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
-      | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
-  end
-
-  (** [int63_is_immediate] reveals the implementation of {!Int63.t} on the
-      current platform, and can be used to build [Int63] operations that behave
-      differently depending on the underlying representation, such as FFIs. *)
-  val int63_is_immediate : (Int63.t, int, Int63_boxed.t) Conditional.t
+    (** [is_immediate] reveals the implementation of {!t} on the current
+        platform, and can be used to build [Int63] operations that behave
+        differently depending on the underlying representation, such as FFIs. *)
+  val is_immediate : (t, int, Boxed.t) Conditional.t
 end


### PR DESCRIPTION
This adds the following type and value:

```ocaml
(** A conditional type equality, used for revealing that a type [t] has one of
    two possible implementation types [u] and [v]. *)
module Conditional : sig
  type ('t, 'u, 'v) t =
    | True : ('t, 't, _) t (** therefore ['t] = ['u] *)
    | False : ('t, _, 't) t (** therefore ['t] = ['v] *)
end

(** [int63_is_immediate] reveals the implementation of {!t} on the current
    platform, and can be used to build [Int63] operations that behave
    differently depending on the underlying representation, such as FFIs. *)
val int63_is_immediate : (Int63.t, int, Int63.Boxed.t) Conditional.t
```

In short, a way for Optint to (optionally) tell the user that `Int63.t` = `int`. This is important when adding efficient operations to 63-bit integers (for instance, see [here](https://github.com/mirage/index/blob/2d08a7ef749809b86742025c202b90ff71670c18/src/unix/syscalls.ml#L9-L18) where this is used to pick a non-allocating C-stub when possible).

@dinosaure: I know that you're not so happy about exposing this information to users, so feel free to critique :-) As an intermediate step, we could perhaps make these values more private (hide them inside `module Private` or `module Unstable` or some such).