### PR TITLE
Use bit-wise infix operators

### DIFF
--- a/src/int63_emul.ml
+++ b/src/int63_emul.ml
@@ -139,8 +139,8 @@ module Infix = struct
   let ( * ) a b = mul a b
   let ( % ) a b = rem a b
   let ( / ) a b = div a b
-  let ( && ) a b = logand a b
-  let ( || ) a b = logor a b
-  let ( >> ) a b = shift_right a b
-  let ( << ) a b = shift_left a b
+  let ( land ) a b = logand a b
+  let ( lor ) a b = logor a b
+  let ( lsr ) a b = shift_right a b
+  let ( lsl ) a b = shift_left a b
 end

--- a/src/int63_emul.ml
+++ b/src/int63_emul.ml
@@ -143,4 +143,10 @@ module Infix = struct
   let ( lor ) a b = logor a b
   let ( lsr ) a b = shift_right a b
   let ( lsl ) a b = shift_left a b
+
+  let ( && ) = ( land )
+  let ( || ) = ( lor )
+  let ( >> ) = ( lsr )
+  let ( << ) = ( lsl )
+
 end

--- a/src/int63_native.ml
+++ b/src/int63_native.ml
@@ -86,4 +86,10 @@ module Infix = struct
   let ( lor ) a b = logor a b
   let ( lsr ) a b = shift_right a b
   let ( lsl ) a b = shift_left a b
+
+  let ( && ) = ( land )
+  let ( || ) = ( lor )
+  let ( >> ) = ( lsr )
+  let ( << ) = ( lsl )
+
 end

--- a/src/int63_native.ml
+++ b/src/int63_native.ml
@@ -82,8 +82,8 @@ module Infix = struct
   let ( * ) a b = mul a b
   let ( % ) a b = rem a b
   let ( / ) a b = div a b
-  let ( && ) a b = logand a b
-  let ( || ) a b = logor a b
-  let ( >> ) a b = shift_right a b
-  let ( << ) a b = shift_left a b
+  let ( land ) a b = logand a b
+  let ( lor ) a b = logor a b
+  let ( lsr ) a b = shift_right a b
+  let ( lsl ) a b = shift_left a b
 end

--- a/src/integer_interface.ml
+++ b/src/integer_interface.ml
@@ -164,12 +164,12 @@ module type S = sig
     val ( lsl ) : t -> int -> t
 
     val ( && ) : t -> t -> t
-    [@@@ocaml.deprecated "Please use ( land )."]
+    [@@ocaml.deprecated "Please use ( land )."]
     val ( || ) : t -> t -> t
-    [@@@ocaml.deprecated "Please use ( lor )."]
+    [@@ocaml.deprecated "Please use ( lor )."]
     val ( >> ) : t -> int -> t
-    [@@@ocaml.deprecated "Please use ( lsr )."]
+    [@@ocaml.deprecated "Please use ( lsr )."]
     val ( << ) : t -> int -> t
-    [@@@ocaml.deprecated "Please use ( lsl )."]
+    [@@ocaml.deprecated "Please use ( lsl )."]
   end
 end

--- a/src/integer_interface.ml
+++ b/src/integer_interface.ml
@@ -158,9 +158,9 @@ module type S = sig
     val ( * ) : t -> t -> t
     val ( % ) : t -> t -> t
     val ( / ) : t -> t -> t
-    val ( && ) : t -> t -> t
-    val ( || ) : t -> t -> t
-    val ( >> ) : t -> int -> t
-    val ( << ) : t -> int -> t
+    val ( land ) : t -> t -> t
+    val ( lor ) : t -> t -> t
+    val ( lsr ) : t -> int -> t
+    val ( lsl ) : t -> int -> t
   end
 end

--- a/src/integer_interface.ml
+++ b/src/integer_interface.ml
@@ -162,5 +162,14 @@ module type S = sig
     val ( lor ) : t -> t -> t
     val ( lsr ) : t -> int -> t
     val ( lsl ) : t -> int -> t
+
+    val ( && ) : t -> t -> t
+    [@@@ocaml.deprecated "Please use ( land )."]
+    val ( || ) : t -> t -> t
+    [@@@ocaml.deprecated "Please use ( lor )."]
+    val ( >> ) : t -> int -> t
+    [@@@ocaml.deprecated "Please use ( lsr )."]
+    val ( << ) : t -> int -> t
+    [@@@ocaml.deprecated "Please use ( lsl )."]
   end
 end

--- a/src/optint_emul.ml
+++ b/src/optint_emul.ml
@@ -76,8 +76,8 @@ module Infix = struct
   let ( % ) a b = rem a b
   let ( / ) a b = div a b
 
-  let ( && ) a b = logand a b
-  let ( || ) a b = logor a b
-  let ( >> ) a b = shift_right a b
-  let ( << ) a b = shift_left a b
+  let ( land ) a b = logand a b
+  let ( lor ) a b = logor a b
+  let ( lsr ) a b = shift_right a b
+  let ( lsl ) a b = shift_left a b
 end

--- a/src/optint_emul.ml
+++ b/src/optint_emul.ml
@@ -80,4 +80,10 @@ module Infix = struct
   let ( lor ) a b = logor a b
   let ( lsr ) a b = shift_right a b
   let ( lsl ) a b = shift_left a b
+
+  let ( && ) = ( land )
+  let ( || ) = ( lor )
+  let ( >> ) = ( lsr )
+  let ( << ) = ( lsl )
+
 end

--- a/src/optint_native.ml
+++ b/src/optint_native.ml
@@ -113,8 +113,8 @@ module Infix = struct
   let ( % ) a b = rem a b
   let ( / ) a b = div a b
 
-  let ( && ) a b = logand a b
-  let ( || ) a b = logor a b
-  let ( >> ) a b = shift_right a b
-  let ( << ) a b = shift_left a b
+  let ( land ) a b = logand a b
+  let ( lor ) a b = logor a b
+  let ( lsr ) a b = shift_right a b
+  let ( lsl ) a b = shift_left a b
 end

--- a/src/optint_native.ml
+++ b/src/optint_native.ml
@@ -117,4 +117,10 @@ module Infix = struct
   let ( lor ) a b = logor a b
   let ( lsr ) a b = shift_right a b
   let ( lsl ) a b = shift_left a b
+
+  let ( && ) = ( land )
+  let ( || ) = ( lor )
+  let ( >> ) = ( lsr )
+  let ( << ) = ( lsl )
+
 end


### PR DESCRIPTION
Instead of shadowing, among other things, the (lazy) boolean operators use the bit-wise infix int operators.

This is a breaking change.

I can as well keep the previous infix operators and deprecate them in order to have a more smooth transition.