### PR TITLE
Remove an unnecessary special case in [div].

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name optint)
 (version dev)

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -3,17 +3,21 @@
  (modules fuzz)
  (libraries fmt crowbar optint))
 
-(alias
- (name runtest)
- (deps (:fuzz fuzz.exe))
- (action (run %{fuzz})))
+(rule
+ (alias runtest)
+ (deps
+  (:fuzz fuzz.exe))
+ (action
+  (run %{fuzz})))
 
 (executable
  (name fuzz_int63)
  (modules fuzz_int63)
  (libraries monolith optint))
 
-(alias
- (name monolith)
- (deps (:fuzz fuzz_int63.exe))
- (action (run %{fuzz})))
+(rule
+ (alias monolith)
+ (deps
+  (:fuzz fuzz_int63.exe))
+ (action
+  (run %{fuzz})))

--- a/optint.opam
+++ b/optint.opam
@@ -24,4 +24,5 @@ depends: [
   "crowbar" {with-test & >= "0.2"}
   "monolith" {with-test}
   "fmt" {with-test}
+  "alcotest" {with-test}
 ]

--- a/src/int63_emul.ml
+++ b/src/int63_emul.ml
@@ -66,12 +66,7 @@ let pred x = sub x one
 let mul x y = Int64.mul x (Conv.unwrap y)
 let div x y =
   let r = Int64.div x y in
-  if Int64.equal r 0x4000_0000_0000_0000L then
-    (* This case happens when we overflow via [ min_int / 1 ], in which case we
-       should wrap back to [ min_int ]. *)
-    min_int
-  else
-    Conv.wrap_modulo r
+  Conv.wrap_modulo r
 
 let lognot x = unset_bottom_bit (Int64.lognot x)
 let logxor x y = unset_bottom_bit (Int64.logxor x y)

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,11 @@
+(executable
+ (name test)
+ (libraries optint alcotest))
+
+(rule
+ (alias runtest)
+ (package optint)
+ (deps
+  (:test test.exe))
+ (action
+  (run %{test} --color=always)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,9 @@
+let int63 = Alcotest.testable Optint.Int63.pp Optint.Int63.equal
+
+let test00 =
+  Alcotest.test_case "Int63.div" `Quick @@ fun () ->
+  let open Optint in
+  Alcotest.(check int63) "div" (Int63.div Int63.min_int Int63.one) Int63.min_int;
+  Alcotest.(check int63) "div" Int63.(div (succ max_int) one) Int63.min_int
+
+let () = Alcotest.run "optint" [ ("int63", [ test00 ]) ]


### PR DESCRIPTION
`0x4000... * 2` already happens to be `0x8000...`, which also happens to be the `min_int`, so the special case is unnecessary.

@craigfe, I'm sure this code was written for a reason, but presumably that reason is gone now? (sorry if I'm missing something)