### PR TITLE
Update README & opam descr w/ wrapped change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Optint - Efficient integer types on 64-bit architectures
 ========================================================
 
-This library provides two new integer types, `Optint.t` and `Int63.t`, which
-guarantee efficient representation on 64-bit architectures and provide a
+This library provides two new integer types, `Optint.t` and `Optint.Int63.t`,
+which guarantee efficient representation on 64-bit architectures and provide a
 best-effort boxed representation on 32-bit architectures.
 
 ## Goal
@@ -19,9 +19,9 @@ This library provides types to do exactly this:
   immediate integer; on 32-bit, it is a boxed 32-bit value. The overflow
   behaviour is platform-dependent.
 
-- `Int63.t`: an integer containing _exactly_ 63 bits. On 64-bit, this is an
-  immediate integer; on 32-bit, it is a boxed 64-bit integer that is wrapped to
-  provide 63-bit two's complement semantics. The two implementations are
+- `Optint.Int63.t`: an integer containing _exactly_ 63 bits. On 64-bit, this is
+  an immediate integer; on 32-bit, it is a boxed 64-bit integer that is wrapped
+  to provide 63-bit two's complement semantics. The two implementations are
   observationally equivalent, modulo use of `Marshal` and `Obj`.
 
 In summary:
@@ -33,7 +33,7 @@ In summary:
 | `Stdlib.Int32.t`     | 32-bit boxed ❌     | 32-bit boxed ❌     | Exactly 32 bits    |
 | `Stdlib.Int64.t`     | 64-bit boxed ❌     | 64-bit boxed ❌     | Exactly 64 bits    |
 | `Optint.t` (_new_)   | 32-bit boxed ❌     | 63-bit immediate ✅ | _At least_ 32 bits |
-| `Int63.t` (_new_)    | 64-bit boxed ❌     | 63-bit immediate ✅ | Exactly 63 bits    |
+| `Optint.Int63.t` (_new_) | 64-bit boxed ❌     | 63-bit immediate ✅ | Exactly 63 bits    |
 
 These new types are safe and well-tested, but their architecture-dependent
 implementation makes them unsuitable for use with the `Marshal` module. Use the

--- a/optint.opam
+++ b/optint.opam
@@ -8,8 +8,8 @@ dev-repo:     "git+https://github.com/mirage/optint.git"
 doc:          "https://mirage.github.io/optint/"
 synopsis:     "Efficient integer types on 64-bit architectures"
 description: """
-This library provides two new integer types, `Optint.t` and `Int63.t`, which
-guarantee efficient representation on 64-bit architectures and provide a
+This library provides two new integer types, `Optint.t` and `Optint.Int63.t`,
+which guarantee efficient representation on 64-bit architectures and provide a
 best-effort boxed representation on 32-bit architectures.
 
 Implementation depends on target architecture.


### PR DESCRIPTION
`Int63` was wrapped as `Optint.Int63` quite a while ago, but `Int63` is still referenced in the prose.